### PR TITLE
Update docs related to toml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Create a `gleam.toml` file containing the name of your OTP application:
 ```toml
 # In a new gleam.toml file
 name = "my_cool_project"
+version = "0.0.1"
 ```
 
 Make a `src` directory for your Gleam code to live in:


### PR DESCRIPTION
## Problem
Looks like in the new gleam release `version` is a mandatory filed.

```
==> foo

error: File IO failure

An error occurred while trying to parse this file:

    ./gleam.toml

The error message from the file IO library was:

    missing field `version` at line 1 column 1

```

The error was explanatory enough but I added the version like
```
version = 0.0.1
```

and the error changed to
```
The error message from the file IO library was:

    expected newline, found a period at line 2 column 14
```
which looks completely alien to people(me) whom don't use toml often.


## Proposal
Include the `version` to the sample `toml` config in README file.