### PR TITLE
Support latest gleam version

### DIFF
--- a/lib/mix/tasks/compiler/gleam.ex
+++ b/lib/mix/tasks/compiler/gleam.ex
@@ -1,10 +1,26 @@
 defmodule Mix.Tasks.Compile.Gleam do
   use Mix.Task.Compiler
 
+  @first_gleam_version_not_taking_build_arg "0.18.0-rc1"
+
   def run(_args) do
-    case Mix.shell().cmd("gleam build .") do
+    case Mix.shell().cmd(build_command()) do
       0 -> {:ok, []}
       status -> exit(status)
     end
+  end
+
+  defp build_command do
+    if build_needs_arg?(),
+      do: "gleam build .",
+      else: "gleam build"
+  end
+
+  defp build_needs_arg? do
+    {cmd_output, 0} = System.cmd("gleam", ["-V"])
+    <<"gleam "::utf8, active_version::binary>> = String.trim(cmd_output)
+
+    comparison = Version.compare(active_version, @first_gleam_version_not_taking_build_arg)
+    comparison == :lt
   end
 end

--- a/lib/mix/tasks/compiler/gleam.ex
+++ b/lib/mix/tasks/compiler/gleam.ex
@@ -1,26 +1,10 @@
 defmodule Mix.Tasks.Compile.Gleam do
   use Mix.Task.Compiler
 
-  @first_gleam_version_not_taking_build_arg "0.18.0-rc1"
-
   def run(_args) do
-    case Mix.shell().cmd(build_command()) do
+    case Mix.shell().cmd("gleam build") do
       0 -> {:ok, []}
       status -> exit(status)
     end
-  end
-
-  defp build_command do
-    if build_needs_arg?(),
-      do: "gleam build .",
-      else: "gleam build"
-  end
-
-  defp build_needs_arg? do
-    {cmd_output, 0} = System.cmd("gleam", ["-V"])
-    <<"gleam "::utf8, active_version::binary>> = String.trim(cmd_output)
-
-    comparison = Version.compare(active_version, @first_gleam_version_not_taking_build_arg)
-    comparison == :lt
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MixGleam.MixProject do
   def project do
     [
       app: :mix_gleam,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       name: "mix_gleam",


### PR DESCRIPTION
Prior to these changes, using `mix_gleam` with an installed `gleam` version of `0.18.0-rc1` or higher fails since the more recent `gleam` versions don't support the command syntax `gleam build .`

The changes here check the `gleam` version and run the `build` command with or without that argument, as appropriate.