### PR TITLE
Only attempt to run tests if test module is loaded

### DIFF
--- a/lib/mix/tasks/gleam/test.ex
+++ b/lib/mix/tasks/gleam/test.ex
@@ -38,13 +38,17 @@ defmodule Mix.Tasks.Gleam.Test do
       |> Keyword.get_lazy(:app, fn ->
         raise MixGleam.Error, message: "Unable to find app name"
       end)
-    module = String.to_atom("#{app}_test")
 
     Mix.Task.run("compile")
     Mix.Task.run("app.start")
-    @shell.info("Running #{module}.main")
-    module.main()
 
-    MixGleam.IO.debug_info("Test End")
+    module = String.to_atom("#{app}_test")
+
+    if :erlang.module_loaded(module) do
+      @shell.info("Running #{module}.main")
+      module.main()
+
+      MixGleam.IO.debug_info("Test End")
+    end
   end
 end


### PR DESCRIPTION
This makes `mix gleam.test` work nicely in umbrella applications where every application may not be a gleam application.