### PR TITLE
Avoid warnings about `function aliases/0 is unused`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ compiler and Gleam dependencies:
       app: @app,
       # ...
       archives: [mix_gleam: "~> 0.4.0"],
-      aliases: MixGleam.add_aliases(),
+      aliases: MixGleam.add_aliases(aliases()),
       erlc_paths: ["build/dev/erlang/#{@app}/build"],
       erlc_include_path: "build/dev/erlang/#{@app}/include",
       # ...


### PR DESCRIPTION
```shell
user@debian:~$ mix assets.deploy
warning: function aliases/0 is unused
  mix.exs:68

Compiling 1 file (.gleam)
Compiling 1 file (.erl)
Compiling 2 files (.ex)
Generated tp_phx app
** (Mix) The task "assets.deploy" could not be found
ERROR: Service 'phoenix' failed to build : The command '/bin/sh -c mix help && mix assets.deploy' returned a non-zero code: 1
```