### PR TITLE
Fix date in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.4.0 - 2021-01-10
+## v0.4.0 - 2022-01-10
 
 - Updated to work with the `gleam compile-package` v0.19 API.
 


### PR DESCRIPTION
I believe the date for release v0.4.0 was accidentally left as 2021 instead of bumped to 2022.
Had me wondering if I'm using the right version :)