### PR TITLE
Add missing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,3 @@ $ mkdir src
 
 And add the `build` directory to your `.gitignore` file so Gleam's build
 artefacts are not included in your project.
-
-To test if gleam runs you need to add an entry point module.
-
-## Making sure gleam compiles
-
-1. Create `src/foo.gleam` with contents: `pub fn bar() { "quux" }`
-2. Run `mix compile`. You can now call `:foo.bar()` like you would call any erlang function from Elixir.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you want to write Gleam code in your project, it's a good idea to add
 
 Create `gleam.toml` with the contents:
 
-```
+```toml
 name = "my_gleam_app"
 ```
 
@@ -89,4 +89,4 @@ To test if gleam runs you need to add an entry point module.
 ## Making sure gleam compiles
 
 1. Create `src/foo.gleam` with contents: `pub fn bar() { "quux" }`
-3. Run `mix compile`. You can now call `:foo.bar()` like you would call any erlang function from Elixir.
+2. Run `mix compile`. You can now call `:foo.bar()` like you would call any erlang function from Elixir.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ If you want to write Gleam code in your project, it's a good idea to add
 # ...
 ```
 
+Create `gleam.toml` with the contents:
+
+```
+name = "my_gleam_app"
+```
+
 Make a `src` directory for your Gleam code to live in:
 
 ```shell
@@ -77,3 +83,10 @@ $ mkdir src
 
 And add the `build` directory to your `.gitignore` file so Gleam's build
 artefacts are not included in your project.
+
+To test if gleam runs you need to add an entry point module.
+
+## Making sure gleam compiles
+
+1. Create `src/foo.gleam` with contents: `pub fn bar() { "quux" }`
+3. Run `mix compile`. You can now call `:foo.bar()` like you would call any erlang function from Elixir.


### PR DESCRIPTION
At least for me without this line it would not work.

Also I was required to add things like gleam_otp to gleam.toml not just to mix.exs, else the IDE would show errors. Is that correct?

Should I also add a note to the instructions about that?