### PR TITLE
Generate gleam.toml in the base project's _build dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "24.2"
-          elixir-version: "1.13.1"
-          gleam-version: "0.19.0-rc4"
+          otp-version: "25.0"
+          elixir-version: "1.13.4"
+          gleam-version: "0.21.0"
       - run: mix do archive.build, archive.install --force
 
       - run: mix deps.get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.0 - UNRELEASED
+
+- Gleam code is now compiled from Mix's `_build` directory. The presence of
+  `gleam.toml` in a project's base directory is no longer required.
+
 ## v0.4.0 - 2022-01-10
 
 - Updated to work with the `gleam compile-package` v0.19 API.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MixGleam.MixProject do
   def project do
     [
       app: :mix_gleam,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       name: "mix_gleam",

--- a/test_projects/basic_project/gleam.toml
+++ b/test_projects/basic_project/gleam.toml
@@ -1,1 +1,0 @@
-name = "basic_project"

--- a/test_projects/basic_project/mix.exs
+++ b/test_projects/basic_project/mix.exs
@@ -14,7 +14,7 @@ defmodule BasicProject.MixProject do
 
       # New items added for Gleam compilation
       # compilers: [:gleam | Mix.compilers()],
-      archives: [mix_gleam: "~> 0.4.0"],
+      archives: [mix_gleam: "~> 0.5.0"],
       aliases: MixGleam.add_aliases(),
       erlc_paths: ["build/dev/erlang/#{@app}/build"],
       erlc_include_path: "build/dev/erlang/#{@app}/include"
@@ -32,8 +32,8 @@ defmodule BasicProject.MixProject do
   defp deps do
     [
       # {:mix_gleam, path: "../../"}
-      {:gleam_stdlib, "~> 0.18"},
-      {:gleeunit, "~> 0.5", only: [:dev, :test]}
+      {:gleam_stdlib, "~> 0.21"},
+      {:gleeunit, "~> 0.6", only: [:dev, :test]}
     ]
   end
 end


### PR DESCRIPTION
A minimal `gleam.toml` config with a project name is required by `gleam compile-package`.

The `Gleam.Compile` task will now create one if necessary, in Mix's build directory rather than the project's base directory (to avoid invoking Gleam's language server).

Closes #19.