### PR TITLE
Rename compile task for compatibility with :compilers option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- `mix gleam.compile` task is renamed to `mix compile.gleam` for compatibility
+  with the `:compilers` Mix.Project option.
+- `MixGleam.add_aliases` is deprecated in favor of adding `:gleam` to `:compilers`
+  and specifying an alias for `:"deps.get"`.
+
 ## v0.5.0 - 2022-06-08
 
 - Gleam code is now compiled from Mix's `_build` directory. The presence of

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ compiler and Gleam dependencies:
       # ...
       archives: [mix_gleam: "~> 0.4.0"],
       compilers: [:gleam | Mix.compilers()],
-      aliases: ["deps.get": ["deps.get", "gleam.deps.get"]],
+      aliases: [
+        # or add this alias to your aliases() function
+        "deps.get": ["deps.get", "gleam.deps.get"]
+      ],
       erlc_paths: ["build/dev/erlang/#{@app}/build"],
       erlc_include_path: "build/dev/erlang/#{@app}/include",
       # ...

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ compiler and Gleam dependencies:
       app: @app,
       # ...
       archives: [mix_gleam: "~> 0.4.0"],
-      aliases: MixGleam.add_aliases(aliases()),
+      compilers: [:gleam | Mix.compilers()],
+      aliases: ["deps.get": ["deps.get", "gleam.deps.get"]],
       erlc_paths: ["build/dev/erlang/#{@app}/build"],
       erlc_include_path: "build/dev/erlang/#{@app}/include",
       # ...

--- a/lib/mix/tasks/compile/gleam.ex
+++ b/lib/mix/tasks/compile/gleam.ex
@@ -48,17 +48,7 @@ defmodule Mix.Tasks.Compile.Gleam do
 
       def project do
         [
-          # [...]
-          aliases: MixGleam.add_aliases(),
-
-          # or
-          aliases: [
-            "my.task": ["help"]
-          ]
-          |> MixGleam.add_aliases,
-
-          # or
-          aliases: ["compile.all": ["compile.gleam", "compile.all"]],
+          compilers: [:gleam] ++ Mix.compilers(),
         ]
       end
 

--- a/lib/mix/tasks/compile/gleam.ex
+++ b/lib/mix/tasks/compile/gleam.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Gleam.Compile do
+defmodule Mix.Tasks.Compile.Gleam do
   use Mix.Task
 
   @shortdoc "Compiles Gleam source files"
@@ -16,16 +16,16 @@ defmodule Mix.Tasks.Gleam.Compile do
   ## Examples:
 
       # Compile Gleam to Erlang in the Mix project.
-      mix gleam.compile
+      mix compile.gleam
 
       # Compile Gleam to Erlang in a dependency.
-      mix gleam.compile gleam_stdlib
+      mix compile.gleam gleam_stdlib
 
       # Compile several dependencies.
-      mix gleam.compile gleam_http gleam_otp
+      mix compile.gleam gleam_http gleam_otp
 
       # Force Gleam compilation.
-      mix gleam.compile gleam_plug --force 
+      mix compile.gleam gleam_plug --force
 
       # Prevent Gleam compilation.
       mix deps.compile --no-gleam
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Gleam.Compile do
           |> MixGleam.add_aliases,
 
           # or
-          aliases: ["compile.all": ["gleam.compile", "compile.all"]],
+          aliases: ["compile.all": ["compile.gleam", "compile.all"]],
         ]
       end
 

--- a/lib/mix/tasks/gleam/deps/get.ex
+++ b/lib/mix/tasks/gleam/deps/get.ex
@@ -15,16 +15,6 @@ defmodule Mix.Tasks.Gleam.Deps.Get do
 
       def project do
         [
-          # [...]
-          aliases: MixGleam.add_aliases(),
-
-          # or
-          aliases: [
-            "my.task": ["help"]
-          ]
-          |> MixGleam.add_aliases,
-
-          # or
           aliases: ["deps.get": ["deps.get", "gleam.deps.get"]],
         ]
       end

--- a/lib/mix_gleam.ex
+++ b/lib/mix_gleam.ex
@@ -19,10 +19,11 @@ defmodule MixGleam do
     end)
   end
 
+  @deprecated "Please prepend :gleam to :compilers and add :\"deps.get\" to :aliases following mix_gleam README.md instead"
   def add_aliases(aliases \\ []) do
     aliases
     |> MixGleam.Aliases.append(["deps.get": ["gleam.deps.get"]])
-    |> MixGleam.Aliases.prepend(["compile.all": ["gleam.compile"]])
+    |> MixGleam.Aliases.prepend(["compile.all": ["compile.gleam"]])
   end
 
   def get_config(path \\ "gleam.toml") do

--- a/lib/mix_gleam/config.ex
+++ b/lib/mix_gleam/config.ex
@@ -31,7 +31,10 @@ defmodule MixGleam.Config do
       elixir: "~> #{ex_ver.major}.#{ex_ver.minor}",
       name: "\#{@app}",
       archives: [mix_gleam: "~> #{@version}"],
-      aliases: MixGleam.add_aliases(\),
+      compilers: [:gleam] ++ Mix.compilers(\),
+      aliases: [
+        "deps.get": ["deps.get", "gleam.deps.get"],
+      ],
       erlc_paths: ["build/dev/erlang/\#{@app}/build"],
       erlc_include_path: "build/dev/erlang/\#{@app}/include",
       start_permanent: Mix.env(\) == :prod,
@@ -129,7 +132,7 @@ end)
 
     keys =
       unless nil == split_keys do
-        split_keys 
+        split_keys
       else
         keys
       end

--- a/test_projects/basic_project/mix.exs
+++ b/test_projects/basic_project/mix.exs
@@ -13,9 +13,9 @@ defmodule BasicProject.MixProject do
       deps: deps(),
 
       # New items added for Gleam compilation
-      # compilers: [:gleam | Mix.compilers()],
+      compilers: [:gleam | Mix.compilers()],
       archives: [mix_gleam: "~> 0.5.0"],
-      aliases: MixGleam.add_aliases(),
+      aliases: ["deps.get": ["deps.get", "gleam.deps.get"]],
       erlc_paths: ["build/dev/erlang/#{@app}/build"],
       erlc_include_path: "build/dev/erlang/#{@app}/include"
     ]


### PR DESCRIPTION
Also: deprecate MixGleam.add_aliases