### PR TITLE
Update erlc_paths for Gleam v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.7.0 - 2022-12-03
+- Updated to work with gleam 0.25.0 
+
 ## v0.6.0 - 2022-06-16
 
 - `mix gleam.compile` task is renamed to `mix compile.gleam` for compatibility

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ compiler and Gleam dependencies:
         # or add this alias to your aliases() function
         "deps.get": ["deps.get", "gleam.deps.get"]
       ],
-      erlc_paths: ["build/dev/erlang/#{@app}/build"],
+      erlc_paths: ["build/dev/erlang/#{@app}/_gleam_artefacts"],
+      # Or if you are using gleam<0.25.0
+      # erlc_paths: ["build/dev/erlang/#{@app}/build"],
       erlc_include_path: "build/dev/erlang/#{@app}/include",
       # ...
     ]

--- a/lib/mix_gleam/config.ex
+++ b/lib/mix_gleam/config.ex
@@ -35,7 +35,10 @@ defmodule MixGleam.Config do
       aliases: [
         "deps.get": ["deps.get", "gleam.deps.get"],
       ],
-      erlc_paths: ["build/dev/erlang/\#{@app}/build"],
+      erlc_paths: [
+        "build/dev/erlang/\#{@app}/build",  # for gleam<0.25.0
+        "build/dev/erlang/\#{@app}/_gleam_artefacts"  # for gleam>=0.25.0
+      ],
       erlc_include_path: "build/dev/erlang/\#{@app}/include",
       start_permanent: Mix.env(\) == :prod,
       deps: deps(\),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MixGleam.MixProject do
   def project do
     [
       app: :mix_gleam,
-      version: "0.6.0",
+      version: "0.7.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       name: "mix_gleam",


### PR DESCRIPTION
Fixes https://github.com/gleam-lang/mix_gleam/issues/26 but is not compatible with earlier gleam versions.