### PR TITLE
Adding :eunit to extra application

### DIFF
--- a/lib/mix_gleam/config.ex
+++ b/lib/mix_gleam/config.ex
@@ -50,7 +50,7 @@ defmodule MixGleam.Config do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :eunit]
     ]
   end
 

--- a/test_projects/basic_project/mix.exs
+++ b/test_projects/basic_project/mix.exs
@@ -34,9 +34,9 @@ defmodule BasicProject.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:mix_gleam, path: "../../"}
-      {:gleam_stdlib, "~> 0.28"},
-      {:gleeunit, "~> 0.10", only: [:dev, :test], runtime: false}
+      {:mix_gleam, path: "../../"},
+      {:gleam_stdlib, "~> 0.30"},
+      {:gleeunit, "~> 0.11", only: [:dev, :test], runtime: false}
     ]
   end
 end

--- a/test_projects/basic_project/mix.lock
+++ b/test_projects/basic_project/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "gleam_stdlib": {:hex, :gleam_stdlib, "0.28.1", "78663a81a9259659ae559be56c4e9d4b0f592a83e46aa189ed1fa14510aad198", [:gleam], [], "hexpm", "73f0a89fade5022cbef6d6c3551f9adce7054afce0cb1dc4c6d5ab4ca62d0111"},
-  "gleeunit": {:hex, :gleeunit, "0.10.1", "2f3fb55d240a8ded5fcd3ed563598e6d8dadd0d7b385012a98eb4cc9b33753b0", [:gleam], [{:gleam_stdlib, "~> 0.19", [hex: :gleam_stdlib, repo: "hexpm", optional: false]}], "hexpm", "ecea2de4be6528d36afe74f42a21cdf99966ec36d7f25deb34d47dd0f7977baf"},
+  "gleam_stdlib": {:hex, :gleam_stdlib, "0.30.2", "61b3ce61d93d0288bca5a64c2043ce482e9e3bb8775106f0ff395164f4a482bd", [:gleam], [], "hexpm", "8d8bf3790aa31176b1e1c0b517dd74c86da8235cf3389ea02043ee4fd82ae3dc"},
+  "gleeunit": {:hex, :gleeunit, "0.11.0", "2008028d27f2fec9c055883a9f100dd1672584e583c7386ee67b5aeae263520f", [:gleam], [{:gleam_stdlib, "~> 0.27", [hex: :gleam_stdlib, repo: "hexpm", optional: false]}], "hexpm", "1397e5c4ac4108769ee979939ac39bf7870659c5afb714630deeee16b8272ad5"},
 }

--- a/test_projects/basic_project/test/basic_project_test.gleam
+++ b/test_projects/basic_project/test/basic_project_test.gleam
@@ -13,5 +13,5 @@ pub fn elixir_code_test() {
   let assert World = hello_elixir()
 }
 
-external fn hello_elixir() -> Thing =
-  "Elixir.BasicProject" "hello"
+@external(erlang, "Elixir.BasicProject", "hello")
+fn hello_elixir() -> Thing


### PR DESCRIPTION
The reason for adding :eunit to the extra application is due to

In Elixir v1.15 has some dependency related changes, if an app is not mentioned in the mix.exs then its corresponding paths are not loaded or fetched. I have been using gleeunit from the elixir project 1.14 and it works fine.

Background for this PR:
I came across this issue due to the following issue when compiling gleeunit on Elixir v1.15
"can't find include lib "eunit/include/eunit.hrl". I thought it was an issue with my Erlang installation. Seems not, I have created a standalone Erlang application with eunit and they compile and tests run fine. 
After doing some digging I found that https://elixirforum.com/t/compiling-eredis-with-elixir-1-15-breaks-compilation/56612/7.

According to Jose, :eunit needs to be added to the extra_applications of the mix.exs of the dependency, which is gleeunit/mix.exs file here. I was not able to find the mix.exs on this repo.

The issue is with Elixir v1.15 and its dependency path is based on applications listed in the config. At least this is my understanding so far. I have tried adding the :eunit manually to the gleeunit and it compiles and works correctly. I have checked with the basic_project. 

The con of the PR is I am not able to test it on Elixir v1.14. 

Initially I opened the issue on the gleeunit repo https://github.com/lpil/gleeunit/issues/22. I have closed it there. I have opened the PR here. 

Please let me know how to go forward with this. 
