### PR TITLE
mix gleam.toml [--replace]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.3 - 2024-01-28
+
+- Added `mix gleam.toml [--replace]` task. It generates gleam.toml from mix.exs. This might be useful for Gleam tooling support in Mix projects, such as Gleam LSP.
+
 ## v0.6.2 - 2023-11-16
 
 - Updated for Elixir v1.15 and Gleam v0.32 compatibility. Make sure to set

--- a/lib/mix/tasks/gleam/toml.ex
+++ b/lib/mix/tasks/gleam/toml.ex
@@ -1,0 +1,72 @@
+defmodule Mix.Tasks.Gleam.Toml do
+  use Mix.Task
+  @impl true
+  @shell Mix.shell()
+  def run(argv) do
+    replace =
+      argv
+      |> OptionParser.parse!(switches: [replace: :boolean])
+      |> elem(0)
+      |> Keyword.get(:replace, false)
+
+    Mix.Project.get!()
+    cfg = Mix.Project.config()
+
+    deps =
+      Mix.Dep.load_and_cache()
+      |> Enum.flat_map(fn %Mix.Dep{app: dep, opts: opts} ->
+        dst = Keyword.fetch!(opts, :dest)
+
+        if dst |> Path.join("gleam.toml") |> File.regular?() do
+          [{dep, [path: dst]}]
+        else
+          []
+        end
+      end)
+
+    toml =
+      [
+        name: Keyword.fetch!(cfg, :app),
+        version: Keyword.fetch!(cfg, :version),
+        dependencies: deps
+      ]
+      |> mk_toml
+
+    if replace do
+      Mix.Project.project_file()
+      |> Path.dirname()
+      |> Path.join("gleam.toml")
+      |> File.write!(toml)
+    else
+      @shell.info(toml)
+    end
+  end
+
+  defp mk_toml(x) do
+    x
+    |> Enum.map(&mk_toml_row/1)
+    |> Enum.join("\n")
+  end
+
+  defp mk_toml_row({k, v}), do: "#{mk_toml_key(k)} = #{mk_toml_val(v)}"
+
+  defp mk_toml_key(x) when is_atom(x) or is_binary(x) or is_number(x) do
+    x |> to_string |> inspect
+  end
+
+  defp mk_toml_val(x) do
+    cond do
+      is_map(x) or Keyword.keyword?(x) ->
+        "{#{x |> Enum.map(&mk_toml_row/1) |> Enum.join(",")}}"
+
+      is_list(x) ->
+        "[#{x |> Enum.map(&mk_toml_val/1) |> Enum.join(",")}]"
+
+      is_number(x) ->
+        to_string(x)
+
+      true ->
+        mk_toml_key(x)
+    end
+  end
+end

--- a/lib/mix/tasks/gleam/toml.ex
+++ b/lib/mix/tasks/gleam/toml.ex
@@ -1,5 +1,25 @@
 defmodule Mix.Tasks.Gleam.Toml do
   use Mix.Task
+  @shortdoc "Generates gleam.toml from mix.exs."
+  @moduledoc """
+  #{@shortdoc}
+
+  This might be useful for Gleam tooling support in Mix projects, such as Gleam LSP.
+
+  Print gleam.toml into stdout:
+
+      mix gleam.toml
+
+  Replace gleam.toml file:
+
+      mix gleam.toml --replace
+
+  Automate gleam.toml sync using mix.exs project aliases:
+
+      aliases: [
+        "deps.get": ["deps.get", "gleam.deps.get", "gleam.toml --replace"]
+      ]
+  """
   @impl true
   @shell Mix.shell()
   def run(argv) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule MixGleam.MixProject do
   def project do
     [
       app: :mix_gleam,
-      version: "0.6.2",
+      version: "0.6.3",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       name: "mix_gleam",


### PR DESCRIPTION
Added `mix gleam.toml [--replace]` task. It generates gleam.toml from mix.exs. This might be useful for Gleam tooling support in Mix projects, such as Gleam LSP.